### PR TITLE
Message spoilers

### DIFF
--- a/internal/message/content.go
+++ b/internal/message/content.go
@@ -30,7 +30,7 @@ type Content struct {
 	ctx     context.Context
 	view    *View
 	menu    *gio.Menu
-	spoiler *spoiler
+	spoiler *Spoiler
 	mdview  *mdrender.MarkdownViewer
 	react   *contentReactions
 	child   []gtk.Widgetter
@@ -99,7 +99,7 @@ func (c *Content) SetExtraMenu(menu gio.MenuModeller) {
 
 // SetSpoiler implements Spoiler.
 func (c *Content) SetSpoiler() {
-	spoiler := newSpoiler(c.ctx)
+	spoiler := NewSpoiler(c.ctx)
 	c.spoiler = spoiler
 }
 

--- a/internal/message/spoiler.go
+++ b/internal/message/spoiler.go
@@ -9,7 +9,7 @@ import (
 	"github.com/diamondburned/gotkit/gtkutil/cssutil"
 )
 
-type spoiler struct {
+type Spoiler struct {
 	*gtk.Overlay
 	ctx context.Context
 }
@@ -20,8 +20,8 @@ var spoilerCSS = cssutil.Applier("message-spoiler", `
 	}
 `)
 
-func newSpoiler(ctx context.Context) *spoiler {
-	s := spoiler{
+func NewSpoiler(ctx context.Context) *Spoiler {
+	s := Spoiler{
 		ctx: ctx,
 	}
 

--- a/internal/message/spoiler.go
+++ b/internal/message/spoiler.go
@@ -1,0 +1,43 @@
+package message
+
+import (
+	"context"
+
+	"github.com/diamondburned/gotk4-adwaita/pkg/adw"
+	"github.com/diamondburned/gotk4/pkg/gtk/v4"
+
+	"github.com/diamondburned/gotkit/gtkutil/cssutil"
+)
+
+type spoiler struct {
+	*gtk.Overlay
+	ctx context.Context
+}
+
+var spoilerCSS = cssutil.Applier("message-spoiler", `
+	.message-spoiler {
+		background-color: black;
+	}
+`)
+
+func newSpoiler(ctx context.Context) *spoiler {
+	s := spoiler{
+		ctx: ctx,
+	}
+
+	s.Overlay = gtk.NewOverlay()
+
+	spoilerBin := adw.NewBin()
+	spoilerCSS(spoilerBin)
+	spoilerBin.SetCSSClasses([]string{"message-spoiler", "card"})
+
+	reveal_gesture := gtk.NewGestureClick()
+	reveal_gesture.ConnectReleased(func(nPress int, x, y float64) {
+		spoilerBin.SetVisible(false)
+	})
+
+	spoilerBin.AddController(reveal_gesture)
+	s.Overlay.AddOverlay(spoilerBin)
+
+	return &s
+}


### PR DESCRIPTION
This PR implements custom Spoiler widget used as a overlay on messages wrapped in `||` tags.

**Note**: Putting this as a draft for now, as there are a couple `MarkdownViewer` bugs that needs to be fixed beforehand, and the current spoiler style definitely needs some polishing.

Fixes #152

### TODO:
- [ ] Make spoiler overlay the same size as the message text
- [ ] Refine spoiler style

### Screenshots:
#### Simple message hidden:
![Screenshot from 2023-10-11 19-24-18](https://github.com/diamondburned/gtkcord4/assets/73042332/bd7fceee-a1c4-4931-ac25-ef79658e9311)

#### Simple message visible:
![Screenshot from 2023-10-11 19-25-43](https://github.com/diamondburned/gtkcord4/assets/73042332/9d25a0b0-16d1-4264-b21f-4449fe190867)

#### Textblock/multi-line message hidden:
![Screenshot from 2023-10-11 19-24-30](https://github.com/diamondburned/gtkcord4/assets/73042332/6e901760-0435-45ae-a762-552b645eac1b)