### PR TITLE
Clear message composer on StopEditing

### DIFF
--- a/internal/messages/composer/composer.go
+++ b/internal/messages/composer/composer.go
@@ -531,6 +531,8 @@ func (v *View) StopEditing() {
 
 	v.state.id = 0
 	v.state.editing = false
+	start, end := v.Input.Buffer.Bounds()
+	v.Input.Buffer.Delete(start, end)
 
 	v.SetPlaceholderMarkup("")
 	v.RemoveCSSClass("composer-editing")


### PR DESCRIPTION
Clears the composer when canceling editing a message