### PR TITLE
Simplify `BackButton`

### DIFF
--- a/internal/window/backbutton/backbutton.go
+++ b/internal/window/backbutton/backbutton.go
@@ -11,8 +11,7 @@ const BackButtonIcon = "sidebar-show-symbolic"
 // BackButton is a button that toggles whether or not the fold's sidebar
 // should be revealed.
 type BackButton struct {
-	*gtk.Revealer
-	Button *gtk.ToggleButton
+	*gtk.ToggleButton
 }
 
 // New creates a new fold reveal button. The button is hidden by default until a
@@ -20,19 +19,12 @@ type BackButton struct {
 func New() *BackButton {
 	button := gtk.NewToggleButton()
 	button.SetIconName(BackButtonIcon)
-	button.SetSensitive(false)
+	button.SetVisible(false)
 	button.SetHAlign(gtk.AlignCenter)
 	button.SetVAlign(gtk.AlignCenter)
 
-	revealer := gtk.NewRevealer()
-	revealer.AddCSSClass("adaptive-sidebar-reveal-button")
-	revealer.SetTransitionType(gtk.RevealerTransitionTypeCrossfade)
-	revealer.SetChild(button)
-	revealer.SetRevealChild(false)
-
 	return &BackButton{
-		Revealer: revealer,
-		Button:   button,
+		ToggleButton: button,
 	}
 }
 
@@ -45,18 +37,17 @@ func (b *BackButton) SetIconName(icon string) {
 // sidebar.
 func (b *BackButton) ConnectSplitView(view *adw.OverlaySplitView) {
 	view.NotifyProperty("show-sidebar", func() {
-		b.Button.SetActive(view.ShowSidebar())
+		b.SetActive(view.ShowSidebar())
 	})
 
 	view.NotifyProperty("collapsed", func() {
 		collapsed := view.Collapsed()
-		b.SetRevealChild(collapsed)
-		b.Button.SetSensitive(collapsed)
+		b.Button.SetVisible(collapsed)
 	})
 
 	// Specifically bind to "clicked" rather than notifying on "active" to
 	// prevent infinite recursion.
 	b.Button.ConnectClicked(func() {
-		view.SetShowSidebar(b.Button.Active())
+		view.SetShowSidebar(b.Active())
 	})
 }

--- a/internal/window/chat.go
+++ b/internal/window/chat.go
@@ -70,13 +70,6 @@ var chatPageCSS = cssutil.Applier("window-chatpage", `
 		border-radius: 0;
 		box-shadow: none;
 	}
-	.right-header .adaptive-sidebar-reveal-button {
-		margin: 0;
-	}
-	.right-header .adaptive-sidebar-reveal-button button {
-		margin-left: 8px;
-		margin-right: 4px;
-	}
 	.right-header-label {
 		font-weight: bold;
 	}
@@ -119,7 +112,6 @@ func NewChatPage(ctx context.Context, w *Window) *ChatPage {
 	p.rightTitle.SetHExpand(true)
 
 	back := backbutton.New()
-	back.SetTransitionType(gtk.RevealerTransitionTypeSlideRight)
 
 	newTabButton := gtk.NewButtonFromIconName("list-add-symbolic")
 	newTabButton.SetTooltipText("Open a New Tab")


### PR DESCRIPTION
Remove `gtk.Revealer` and replace it with `SetVisible` method, also remove custom CSS, as it slightly moved button to the right.