### PR TITLE
Port dialogs to `adw.Dialog`

### DIFF
--- a/internal/messages/message.go
+++ b/internal/messages/message.go
@@ -246,16 +246,19 @@ func (m *message) ShowEmojiChooser() {
 	e.Popup()
 }
 
-// ShowSource opens a JSON showing the message JSON.
+// ShowSource opens a dialog showing a JSON representation of the message.
 func (m *message) ShowSource() {
-	d := adw.NewWindow()
+	d := adw.NewDialog()
 	d.SetTitle(locale.Get("View Source"))
-	d.SetTransientFor(app.GTKWindowFromContext(m.ctx()))
-	d.SetModal(true)
-	d.SetDefaultSize(500, 300)
+	d.SetContentWidth(500)
+	d.SetContentHeight(300)
 
 	h := adw.NewHeaderBar()
 	h.SetCenteringPolicy(adw.CenteringPolicyStrict)
+
+	toolbarView := adw.NewToolbarView()
+	toolbarView.SetTopBarStyle(adw.ToolbarFlat)
+	toolbarView.AddTopBar(h)
 
 	buf := gtk.NewTextBuffer(nil)
 
@@ -292,8 +295,10 @@ func (m *message) ShowSource() {
 	box.Append(h)
 	box.Append(s)
 
-	d.SetContent(box)
-	d.Present()
+	toolbarView.SetContent(box)
+
+	d.SetChild(toolbarView)
+	d.Present(app.GTKWindowFromContext(m.ctx()))
 }
 
 // cozyMessage is a large cozy message with an avatar.

--- a/internal/window/about/about.go
+++ b/internal/window/about/about.go
@@ -9,15 +9,12 @@ import (
 
 	"github.com/diamondburned/gotk4-adwaita/pkg/adw"
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
-	"github.com/diamondburned/gotkit/app"
 	"github.com/diamondburned/gotkit/components/logui"
 )
 
 // New creates a new about window.
-func New(ctx context.Context) *adw.AboutWindow {
-	about := adw.NewAboutWindow()
-	about.SetTransientFor(app.GTKWindowFromContext(ctx))
-	about.SetModal(true)
+func New(ctx context.Context) *adw.AboutDialog {
+	about := adw.NewAboutDialog()
 	about.SetApplicationName("Dissent")
 	about.SetApplicationIcon("logo")
 	about.SetVersion("git") // TODO: version

--- a/internal/window/chat.go
+++ b/internal/window/chat.go
@@ -42,7 +42,6 @@ type ChatPage struct {
 	rightTitle  *adw.Bin
 
 	tabView       *adw.TabView
-	quickswitcher *quickswitcher.Dialog
 
 	lastGuildState   *app.TypedSingleState[discord.GuildID]
 	lastChannelState *app.TypedState[discord.ChannelID]
@@ -92,9 +91,6 @@ func NewChatPage(ctx context.Context, w *Window) *ChatPage {
 		lastGuildState:   lastGuildKey.Acquire(ctx),
 		lastChannelState: lastChannelKey.Acquire(ctx),
 	}
-
-	p.quickswitcher = quickswitcher.NewDialog(ctx)
-	p.quickswitcher.SetHideOnClose(true) // so we can reopen it later
 
 	p.tabView = adw.NewTabView()
 	p.tabView.AddCSSClass("window-chatpage-tabview")
@@ -178,7 +174,7 @@ func NewChatPage(ctx context.Context, w *Window) *ChatPage {
 }
 
 // OpenQuickSwitcher opens the Quick Switcher dialog.
-func (p *ChatPage) OpenQuickSwitcher() { p.quickswitcher.Show() }
+func (p *ChatPage) OpenQuickSwitcher() { quickswitcher.ShowDialog(p.ctx) }
 
 // ResetView switches out of any channel view and into the placeholder view.
 // This method is used when the guild becomes unavailable.

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func main() {
 	m.app = app.New(context.Background(), "so.libdb.dissent", "Dissent")
 	m.app.AddJSONActions(map[string]interface{}{
 		"app.preferences": func() { prefui.ShowDialog(m.win.Context()) },
-		"app.about":       func() { about.New(m.win.Context()).Present() },
+		"app.about":       func() { about.New(m.win.Context()).Present(m.win) },
 		"app.logs":        func() { logui.ShowDefaultViewer(m.win.Context()) },
 		"app.quit":        func() { m.app.Quit() },
 	})


### PR DESCRIPTION
Port Quick Switcher and View Source dialogs to `adw.Dialog`, and replace deprecated `AboutWindow` with new `AboutDialog`.